### PR TITLE
Add AlpineJS

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,6 +8,7 @@
         @livewireStyles
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.0.0/dist/trix.css">
   	    <script type="text/javascript" src="https://unpkg.com/trix@2.0.0/dist/trix.umd.min.js"></script>
+        <script src="//unpkg.com/alpinejs" defer></script>
     </head>
     <body>
         <nav class="navbar navbar-expand-md navbar-dark bg-dark d-print-none">


### PR DESCRIPTION
The trix editor used some AlpineJS functions without AlpineJS being installed (x-data, x-on and x-ref):
```html
<trix-editor
    class="trix-content"
    x-data
    x-on:trix-change="$dispatch('input', event.target.value)"
    x-ref="trix"
    wire:model.debounce.60s="item.checks"
    wire:key="uniqueKey"
></trix-editor>
```

Only Livewire 3 (in beta) comes with AlpineJS out of the box.

For whatever reason Chrome did catch the 'input' event that trix sends, whilst firefox seems to need the explicit `$dispatch('input', event.target.value)` on the `trix-change` event. Whether we fix this with AlpineJS or plain javascript doesn't matter, but in this case simply installing AlpineJS was a one line fix.

_PS: I only tested the malfunctioning 'feedbackmoment' modal. No idea if this breaks anything else (it shouldn't)_